### PR TITLE
Allow exiting without stake

### DIFF
--- a/src/crop.sol
+++ b/src/crop.sol
@@ -121,8 +121,13 @@ contract CropJoin {
     function harvest(address from, address to) internal {
         if (total > 0) share = add(share, rdiv(crop(), total));
 
+        uint256 _stake = stake[from];
+        (uint256 ink,) = vat.urns(ilk, from);
+        uint256 gems = add(vat.gem(ilk, from), ink);
+        if (gems < _stake) _stake = gems;
+
         uint256 last = crops[from];
-        uint256 curr = rmul(stake[from], share);
+        uint256 curr = rmul(_stake, share);
         if (curr > last) require(bonus.transfer(to, curr - last));
         stock = bonus.balanceOf(address(this));
     }
@@ -159,7 +164,9 @@ contract CropJoin {
             vat.slip(ilk, msg.sender, -int256(wad));
 
             total = sub(total, wad);
-            stake[msg.sender] = sub(stake[msg.sender], wad);
+            uint256 _stake = stake[msg.sender];
+            if (_stake < wad) wad = _stake;
+            stake[msg.sender] = sub(_stake, wad);
         }
         crops[msg.sender] = rmulup(stake[msg.sender], share);
         emit Exit(val);
@@ -174,7 +181,9 @@ contract CropJoin {
         vat.slip(ilk, msg.sender, -int256(wad));
 
         total = sub(total, wad);
-        stake[msg.sender] = sub(stake[msg.sender], wad);
+        uint256 _stake = stake[msg.sender];
+        if (_stake < wad) wad = _stake;
+        stake[msg.sender] = sub(_stake, wad);
         crops[msg.sender] = rmulup(stake[msg.sender], share);
 
         emit Flee();


### PR DESCRIPTION
This is necessary for liquidators where it's possible to be in a state where you cannot collect together all the stake via `tack()` to exit with your gems. The staking parameter is used to track rewards only and degrading to just exiting the gems seems like a reasonable trade-off. Unfortunately this means that rewards can now be lost if balances are not `tack`ed in a timely manner. I think we need to come up with a more robust solution in general moving forward, but this fix should be enough to get a product online that is "good enough" to work in the common case.