### PR TITLE
Generalize the CropClipper into the ProxyManagerClipper 

### DIFF
--- a/src/CropManager.sol
+++ b/src/CropManager.sol
@@ -143,6 +143,20 @@ contract CropManagerImp {
         CropLike(crop).tack(surp, durp, wad);
     }
 
+    function onLiquidation(address crop, address usr, uint256 wad) external {
+        // NOTE - this is not permissioned so be careful with what is done here
+        // Send any outstanding rewards to usr and tack to the clipper
+        address urp = proxy[usr];
+        require(urp != address(0), "CropManager/non-existing-urp");
+        CropLike(crop).join(urp, usr, 0);
+        CropLike(crop).tack(urp, msg.sender, wad);
+    }
+
+    function onVatFlux(address crop, address from, address to, uint256 wad) external {
+        // NOTE - this is not permissioned so be careful with what is done here
+        CropLike(crop).tack(from, to, wad);
+    }
+
     function quit(bytes32 ilk, address dst) external {
         require(VatLike(vat).live() == 0, "CropManager/vat-still-live");
 

--- a/src/ProxyManagerClipper.sol
+++ b/src/ProxyManagerClipper.sol
@@ -46,35 +46,39 @@ interface AbacusLike {
     function price(uint256, uint256) external view returns (uint256);
 }
 
-interface CropJoinLike {
+interface GemJoinLike {
     function ilk() external returns (bytes32);
-    function tack(address, address, uint256) external;
 }
 
-interface CropJoinManagerLike {
+interface ProxyManagerLike {
     function proxy(address) external returns (address);
-    function join(address, address, uint256) external;
+    function getOrCreateProxy(address) external returns (address);
+    function flux(address, address, address, uint256) external;
+    function onLiquidation(address, address, uint256) external;
+    function onVatFlux(address, address, address, uint256) external;
 }
 
 interface ProxyLike {
     function usr() external view returns (address);
 }
 
-contract CropClipper {
+// Clipper for use with the manager / proxy paradigm
+contract ProxyManagerClipper {
     // --- Auth ---
     mapping (address => uint256) public wards;
     function rely(address usr) external auth { wards[usr] = 1; emit Rely(usr); }
     function deny(address usr) external auth { wards[usr] = 0; emit Deny(usr); }
     modifier auth {
-        require(wards[msg.sender] == 1, "CropClipper/not-authorized");
+        require(wards[msg.sender] == 1, "ProxyManagerClipper/not-authorized");
         _;
     }
 
     // --- Data ---
-    bytes32             immutable public ilk;      // Collateral type of this CropClipper
-    VatLike             immutable public vat;      // Core CDP Engine
-    CropJoinLike        immutable public crop;     // CropJoin adapter this contract performs liquidations for
-    CropJoinManagerLike immutable public cropMgr;  // The crop proxy manager
+    bytes32          immutable public ilk;      // Collateral type of this ProxyManagerClipper
+    VatLike          immutable public vat;      // Core CDP Engine
+    GemJoinLike      immutable public gemJoin;  // GemJoin adapter this contract performs liquidations for
+    ProxyManagerLike immutable public proxyMgr; // The proxy manager
+    address          immutable public proxy;    // The proxy for this clipper
 
     DogLike     public dog;      // Liquidation module
     address     public vow;      // Recipient of dai raised in auctions
@@ -148,28 +152,29 @@ contract CropClipper {
     event Yank(uint256 id);
 
     // --- Init ---
-    constructor(address vat_, address spotter_, address dog_, address crop_, address cropMgr_) public {
-        vat     = VatLike(vat_);
-        spotter = SpotterLike(spotter_);
-        dog     = DogLike(dog_);
-        crop    = CropJoinLike(crop_);
-        cropMgr = CropJoinManagerLike(cropMgr_);
-        ilk     = CropJoinLike(crop_).ilk();
-        buf     = RAY;
+    constructor(address vat_, address spotter_, address dog_, address gemJoin_, address proxyMgr_) public {
+        vat      = VatLike(vat_);
+        spotter  = SpotterLike(spotter_);
+        dog      = DogLike(dog_);
+        gemJoin  = GemJoinLike(gemJoin_);
+        proxyMgr = ProxyManagerLike(proxyMgr_);
+        proxy    = ProxyManagerLike(proxyMgr_).getOrCreateProxy(address(this));
+        ilk      = GemJoinLike(gemJoin_).ilk();
+        buf      = RAY;
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
     }
 
     // --- Synchronization ---
     modifier lock {
-        require(locked == 0, "CropClipper/system-locked");
+        require(locked == 0, "ProxyManagerClipper/system-locked");
         locked = 1;
         _;
         locked = 0;
     }
 
     modifier isStopped(uint256 level) {
-        require(stopped < level, "CropClipper/stopped-incorrect");
+        require(stopped < level, "ProxyManagerClipper/stopped-incorrect");
         _;
     }
 
@@ -181,7 +186,7 @@ contract CropClipper {
         else if (what == "chip")       chip = uint64(data);   // Percentage of tab to incentivize (max: 2^64 - 1 => 18.xxx WAD = 18xx%)
         else if (what == "tip")         tip = uint192(data);  // Flat fee to incentivize keepers (max: 2^192 - 1 => 6.277T RAD)
         else if (what == "stopped") stopped = data;           // Set breaker (0, 1, 2, or 3)
-        else revert("CropClipper/file-unrecognized-param");
+        else revert("ProxyManagerClipper/file-unrecognized-param");
         emit File(what, data);
     }
     function file(bytes32 what, address data) external auth lock {
@@ -189,7 +194,7 @@ contract CropClipper {
         else if (what == "dog")    dog = DogLike(data);
         else if (what == "vow")    vow = data;
         else if (what == "calc")  calc = AbacusLike(data);
-        else revert("CropClipper/file-unrecognized-param");
+        else revert("ProxyManagerClipper/file-unrecognized-param");
         emit File(what, data);
     }
 
@@ -229,7 +234,7 @@ contract CropClipper {
     function getFeedPrice() internal returns (uint256 feedPrice) {
         (PipLike pip, ) = spotter.ilks(ilk);
         (bytes32 val, bool has) = pip.peek();
-        require(has, "CropClipper/invalid-price");
+        require(has, "ProxyManagerClipper/invalid-price");
         feedPrice = rdiv(mul(uint256(val), BLN), spotter.par());
     }
 
@@ -249,11 +254,11 @@ contract CropClipper {
         address kpr   // Address that will receive incentives
     ) external auth lock isStopped(1) returns (uint256 id) {
         // Input validation
-        require(tab  >          0, "CropClipper/zero-tab");
-        require(lot  >          0, "CropClipper/zero-lot");
-        require(usr != address(0), "CropClipper/zero-usr");
+        require(tab  >          0, "ProxyManagerClipper/zero-tab");
+        require(lot  >          0, "ProxyManagerClipper/zero-lot");
+        require(usr != address(0), "ProxyManagerClipper/zero-usr");
         id = ++kicks;
-        require(id   >          0, "CropClipper/overflow");
+        require(id   >          0, "ProxyManagerClipper/overflow");
 
         active.push(id);
 
@@ -266,7 +271,7 @@ contract CropClipper {
 
         uint256 top;
         top = rmul(getFeedPrice(), buf);
-        require(top > 0, "CropClipper/zero-top-price");
+        require(top > 0, "ProxyManagerClipper/zero-top-price");
         sales[id].top = top;
 
         // incentive to kick auction
@@ -278,9 +283,8 @@ contract CropClipper {
             vat.suck(vow, kpr, coin);
         }
 
-        // Give any outstanding rewards to vault owner and move the stake over to this contract
-        cropMgr.join(address(crop), ProxyLike(usr).usr(), 0);
-        crop.tack(usr, address(this), lot);
+        // Trigger proxy manager liquidation call-back
+        proxyMgr.onLiquidation(address(gemJoin), ProxyLike(usr).usr(), lot);
 
         emit Kick(id, top, tab, lot, usr, kpr, coin);
     }
@@ -296,12 +300,12 @@ contract CropClipper {
         uint96  tic = sales[id].tic;
         uint256 top = sales[id].top;
 
-        require(usr != address(0), "CropClipper/not-running-auction");
+        require(usr != address(0), "ProxyManagerClipper/not-running-auction");
 
         // Check that auction needs reset
         // and compute current price [ray]
         (bool done,) = status(tic, top);
-        require(done, "CropClipper/cannot-reset");
+        require(done, "ProxyManagerClipper/cannot-reset");
 
         uint256 tab   = sales[id].tab;
         uint256 lot   = sales[id].lot;
@@ -309,7 +313,7 @@ contract CropClipper {
 
         uint256 feedPrice = getFeedPrice();
         top = rmul(feedPrice, buf);
-        require(top > 0, "CropClipper/zero-top-price");
+        require(top > 0, "ProxyManagerClipper/zero-top-price");
         sales[id].top = top;
 
         // incentive to redo auction
@@ -334,10 +338,10 @@ contract CropClipper {
     // amount of collateral purchased will instead be just enough to collect `tab` DAI.
     //
     // To avoid partial purchases resulting in very small leftover auctions that will
-    // never be cleared, any partial purchase must leave at least `CropClipper.chost`
+    // never be cleared, any partial purchase must leave at least `ProxyManagerClipper.chost`
     // remaining DAI target. `chost` is an asynchronously updated value equal to
     // (Vat.dust * Dog.chop(ilk) / WAD) where the values are understood to be determined
-    // by whatever they were when CropClipper.upchost() was last called. Purchase amounts
+    // by whatever they were when ProxyManagerClipper.upchost() was last called. Purchase amounts
     // will be minimally decreased when necessary to respect this limit; i.e., if the
     // specified `amt` would leave `tab < chost` but `tab > 0`, the amount actually
     // purchased will be such that `tab == chost`.
@@ -355,7 +359,7 @@ contract CropClipper {
         address usr = sales[id].usr;
         uint96  tic = sales[id].tic;
 
-        require(usr != address(0), "CropClipper/not-running-auction");
+        require(usr != address(0), "ProxyManagerClipper/not-running-auction");
 
         uint256 price;
         {
@@ -363,11 +367,11 @@ contract CropClipper {
             (done, price) = status(tic, sales[id].top);
 
             // Check that auction doesn't need reset
-            require(!done, "CropClipper/needs-reset");
+            require(!done, "ProxyManagerClipper/needs-reset");
         }
 
         // Ensure price is acceptable to buyer
-        require(max >= price, "CropClipper/too-expensive");
+        require(max >= price, "ProxyManagerClipper/too-expensive");
 
         uint256 lot = sales[id].lot;
         uint256 tab = sales[id].tab;
@@ -391,7 +395,7 @@ contract CropClipper {
                 uint256 _chost = chost;
                 if (tab - owe < _chost) {    // safe as owe < tab
                     // If tab <= chost, buyers have to take the entire lot.
-                    require(tab > _chost, "CropClipper/no-partial-purchase");
+                    require(tab > _chost, "ProxyManagerClipper/no-partial-purchase");
                     // Adjust amount to pay
                     owe = tab - _chost;      // owe' <= owe
                     // Adjust slice
@@ -406,15 +410,16 @@ contract CropClipper {
 
             // Send collateral to the UrnProxy of who
             {
-                address urp = cropMgr.proxy(who);
-                require(urp != address(0), "CropClipper/no-urn-proxy");
-                vat.flux(ilk, address(this), urp, slice);
-                crop.tack(address(this), urp, slice);  // Transfer stake+rewards
+                address urp = proxyMgr.proxy(who);
+                require(urp != address(0), "ProxyManagerClipper/no-urn-proxy");
+                vat.flux(ilk, address(this), proxy, slice);
+                proxyMgr.onVatFlux(address(gemJoin), address(this), proxy, slice);
+                proxyMgr.flux(address(gemJoin), address(this), who, slice);
             }
 
             // Do external call (if data is defined) but to be
             // extremely careful we don't allow to do it to the two
-            // contracts which the CropClipper needs to be authorized
+            // contracts which the ProxyManagerClipper needs to be authorized
             DogLike dog_ = dog;
             if (data.length > 0 && who != address(vat) && who != address(dog_)) {
                 ClipperCallee(who).clipperCall(msg.sender, owe, slice, data);
@@ -430,8 +435,9 @@ contract CropClipper {
         if (lot == 0) {
             _remove(id);
         } else if (tab == 0) {
-            vat.flux(ilk, address(this), usr, lot);
-            crop.tack(address(this), usr, lot);  // Transfer stake+rewards
+            vat.flux(ilk, address(this), proxy, lot);
+            proxyMgr.onVatFlux(address(gemJoin), address(this), proxy, lot);
+            proxyMgr.flux(address(gemJoin), address(this), ProxyLike(usr).usr(), lot);
             _remove(id);
         } else {
             sales[id].tab = tab;
@@ -490,11 +496,11 @@ contract CropClipper {
 
     // Cancel an auction during ES or via governance action.
     function yank(uint256 id) external auth lock {
-        require(sales[id].usr != address(0), "CropClipper/not-running-auction");
+        require(sales[id].usr != address(0), "ProxyManagerClipper/not-running-auction");
         dog.digs(ilk, sales[id].tab);
         uint256 lot = sales[id].lot;
         vat.flux(ilk, address(this), msg.sender, lot);
-        crop.tack(address(this), msg.sender, lot);
+        proxyMgr.onVatFlux(address(gemJoin), address(this), msg.sender, lot);
         _remove(id);
         emit Yank(id);
     }

--- a/src/test/CropClipper-integration.t.sol
+++ b/src/test/CropClipper-integration.t.sol
@@ -18,7 +18,7 @@ pragma solidity 0.6.12;
 import "./TestBase.sol";
 import {CropJoin} from "../CropJoin.sol";
 import {CropManager,CropManagerImp} from "../CropManager.sol";
-import {CropClipper} from "../CropClipper.sol";
+import {ProxyManagerClipper} from "../ProxyManagerClipper.sol";
 import {Usr} from './CropManager-unit.t.sol';
 
 interface VatLike {
@@ -109,7 +109,7 @@ contract CropperIntegrationTest is TestBase {
     Token bonus;
     CropJoin join;
     CropManagerImp manager;
-    CropClipper cropper;
+    ProxyManagerClipper cropper;
     Pip pip;
     Abacus abacus;
     bytes32 constant ILK = "GEM-A";
@@ -150,7 +150,7 @@ contract CropperIntegrationTest is TestBase {
         CropManager base = new CropManager();
         base.setImplementation(address(new CropManagerImp(address(vat))));
         manager = CropManagerImp(address(base));
-        cropper = new CropClipper(address(vat), address(spotter), address(dog), address(join), address(manager));
+        cropper = new ProxyManagerClipper(address(vat), address(spotter), address(dog), address(join), address(manager));
 
         // Auth setup
         cropper.rely(address(dog));

--- a/src/test/ProxyManagerClipper-integration.t.sol
+++ b/src/test/ProxyManagerClipper-integration.t.sol
@@ -103,13 +103,13 @@ contract Abacus is Pip {
     }
 }
 
-contract CropperIntegrationTest is TestBase {
+contract ProxyManagerClipperIntegrationTest is TestBase {
     
     Token gem;
     Token bonus;
     CropJoin join;
     CropManagerImp manager;
-    ProxyManagerClipper cropper;
+    ProxyManagerClipper clipper;
     Pip pip;
     Abacus abacus;
     bytes32 constant ILK = "GEM-A";
@@ -150,11 +150,11 @@ contract CropperIntegrationTest is TestBase {
         CropManager base = new CropManager();
         base.setImplementation(address(new CropManagerImp(address(vat))));
         manager = CropManagerImp(address(base));
-        cropper = new ProxyManagerClipper(address(vat), address(spotter), address(dog), address(join), address(manager));
+        clipper = new ProxyManagerClipper(address(vat), address(spotter), address(dog), address(join), address(manager));
 
         // Auth setup
-        cropper.rely(address(dog));
-        dog.rely(address(cropper));
+        clipper.rely(address(dog));
+        dog.rely(address(clipper));
         vat.rely(address(join));
         join.rely(address(manager));
         join.deny(address(this));    // Only access should be through manager
@@ -162,13 +162,13 @@ contract CropperIntegrationTest is TestBase {
         // Initialize GEM-A in the Dog
         dog.file(ILK, "hole", 10**6 * RAD);
         dog.file("Hole", add(dog.Hole(), 10**6 * RAD));
-        dog.file(ILK, "clip", address(cropper));
+        dog.file(ILK, "clip", address(clipper));
         dog.file(ILK, "chop", 110 * WAD / 100);
 
         // Set up pricing
         abacus = new Abacus();
         abacus.set(mul(pip.val(), 10**9));
-        cropper.file("calc", address(abacus));
+        clipper.file("calc", address(abacus));
 
         // Create Vault
         usr = new Usr(join, manager);
@@ -186,19 +186,19 @@ contract CropperIntegrationTest is TestBase {
         manager.join(address(join), address(this), 10**4 * WAD);
         manager.frob(address(join), address(this), address(this), address(this), int256(10**4 * WAD), int256(1000 * WAD));
 
-        // Hope the cropper so we can bid.
-        vat.hope(address(cropper));
+        // Hope the clipper so we can bid.
+        vat.hope(address(clipper));
 
         // Simulate fee collection; usr's Vault becomes unsafe.
-        vat.fold(ILK, cropper.vow(), int256(RAY / 5));
+        vat.fold(ILK, clipper.vow(), int256(RAY / 5));
     }
 
     function test_kick_via_bark() public {
         assertEq(usr.stake(), 10**3 * WAD);
-        assertEq(join.stake(address(cropper)), 0);
+        assertEq(join.stake(address(clipper)), 0);
         dog.bark(ILK, usr.proxy(), address(this));
         assertEq(usr.stake(), 0);
-        assertEq(join.stake(address(cropper)), 10**3 * WAD);
+        assertEq(join.stake(address(clipper)), 10**3 * WAD);
     }
 
     function test_take_all() public {
@@ -217,16 +217,16 @@ contract CropperIntegrationTest is TestBase {
         abacus.set(price);
 
         // Assert that the statement above is indeed true.
-        (, uint256 tab, uint256 lot,,,) = cropper.sales(id);
+        (, uint256 tab, uint256 lot,,,) = clipper.sales(id);
         assertTrue(mul(lot, price) < tab);
 
         // Ensure that we have enough DAI to cover our purchase.
         assertTrue(mul(lot, price) < vat.dai(address(this)));
 
         bytes memory emptyBytes;
-        cropper.take(id, lot, price, address(this), emptyBytes);
+        clipper.take(id, lot, price, address(this), emptyBytes);
 
-        (, tab, lot,,,) = cropper.sales(id);
+        (, tab, lot,,,) = clipper.sales(id);
         assertEq(tab, 0);
         assertEq(lot, 0);
 
@@ -254,7 +254,7 @@ contract CropperIntegrationTest is TestBase {
         abacus.set(price);
 
         // Assert that the statement above is indeed true.
-        (, uint256 tab, uint256 lot,,,) = cropper.sales(id);
+        (, uint256 tab, uint256 lot,,,) = clipper.sales(id);
         assertTrue(mul(lot, price) > tab);
 
         // Ensure that we have enough DAI to cover our purchase.
@@ -263,9 +263,9 @@ contract CropperIntegrationTest is TestBase {
         uint256 expectedPurchaseSize = tab / price;
 
         bytes memory emptyBytes;
-        cropper.take(id, lot, price, address(this), emptyBytes);
+        clipper.take(id, lot, price, address(this), emptyBytes);
 
-        (, tab, lot,,,) = cropper.sales(id);
+        (, tab, lot,,,) = clipper.sales(id);
         assertEq(tab, 0);
         assertEq(lot, 0);
 
@@ -294,7 +294,7 @@ contract CropperIntegrationTest is TestBase {
 
         uint256 id = dog.bark(ILK, usr.proxy(), address(this));
 
-        cropper.yank(id);
+        clipper.yank(id);
 
         // The collateral has been transferred to this contract specifically--
         // yank gets called by the End, which has no UrnProxy.


### PR DESCRIPTION
It seems likely we will be using this Proxy / Manager paradigm moving forward. It's been used for `dss-crop-join`, but also being used for `dss-charter`. It makes sense to generalize the clipper if we can. This is my attempt to do so using callbacks to keep the state in a good place. It's maybe not the most elegant solution, and it seems like we may run into edge cases in the future, but it should work for both examples so far.

Luckily both `onLiquidation` and `onVatFlux` can be done in a permissionless way, but if in the future these need to be permissioned we can do so by authorizing the clipper on the manager. This doesn't change the `ProxyManagerClipper`, so I think it's okay to permission the callbacks if needed.