### PR TITLE
Get val on flee(), use flee() on cash

### DIFF
--- a/src/CropJoin.sol
+++ b/src/CropJoin.sol
@@ -228,10 +228,12 @@ contract CropJoinImp {
         emit Exit(urn, usr, val);
     }
 
-    function flee(address urn, address usr) public auth virtual {
-        uint256 wad = vat.gem(ilk, urn);
-        require(wad <= 2 ** 255);
-        uint256 val = wmul(wmul(wad, nps()), toGemConversionFactor);
+    function flee(address urn, address usr, uint256 val) public auth virtual {
+        uint256 wad = wdivup(mul(val, to18ConversionFactor), nps());
+
+        // Overflow check for int256(wad) cast below
+        // Also enforces a non-zero wad
+        require(int256(wad) > 0);
 
         require(gem.transfer(usr, val));
         vat.slip(ilk, urn, -int256(wad));

--- a/src/Cropper.sol
+++ b/src/Cropper.sol
@@ -35,7 +35,7 @@ interface CropLike {
     function join(address, address, uint256) external;
     function exit(address, address, uint256) external;
     function tack(address, address, uint256) external;
-    function flee(address, address) external;
+    function flee(address, address, uint256) external;
 }
 
 interface GemLike {
@@ -158,12 +158,12 @@ contract CropperImp {
         CropLike(crop).exit(urp, usr, val);
     }
 
-    function flee(address crop, address usr) external {
+    function flee(address crop, address usr, uint256 val) external {
         require(VatLike(vat).wards(crop) == 1, "Cropper/crop-not-authorized");
 
         address urp = proxy[msg.sender];
         require(urp != address(0), "Cropper/non-existing-urp");
-        CropLike(crop).flee(urp, usr);
+        CropLike(crop).flee(urp, usr, val);
     }
 
     function move(address u, address dst, uint256 rad) external allowed(u) {

--- a/src/SushiJoinV1.sol
+++ b/src/SushiJoinV1.sol
@@ -118,12 +118,11 @@ contract SushiJoinImp is CropJoinImp {
         super.exit(urn, usr, val);
     }
 
-    function flee(address urn, address usr) public override {
+    function flee(address urn, address usr, uint256 val) public override {
         if (live == 1) {
-            uint256 val = vat.gem(ilk, urn);
             masterchef.withdraw(pid, val);
         }
-        super.flee(urn, usr);
+        super.flee(urn, usr, val);
     }
     function cage() override public {
         require(live == 1, "SushiJoin/not-live");

--- a/src/SushiJoinV2.sol
+++ b/src/SushiJoinV2.sol
@@ -128,12 +128,11 @@ contract SushiJoinImp is CropJoinImp {
         super.exit(urn, usr, val);
     }
 
-    function flee(address urn, address usr) public override {
+    function flee(address urn, address usr, uint256 val) public override {
         if (live == 1) {
-            uint256 val = vat.gem(ilk, urn);
             masterchef.withdraw(pid, val, address(this));
         }
-        super.flee(urn, usr);
+        super.flee(urn, usr, val);
     }
 
     function cage() override public {

--- a/src/SynthetixJoin.sol
+++ b/src/SynthetixJoin.sol
@@ -82,12 +82,11 @@ contract SynthetixJoinImp is CropJoinImp {
         super.exit(urn, usr, val);
     }
 
-    function flee(address urn, address usr) public override {
+    function flee(address urn, address usr, uint256 val) public override {
         if (live == 1) {
-            uint256 val = vat.gem(ilk, urn);
             if (val > 0) pool.withdraw(val);
         }
-        super.flee(urn, usr);
+        super.flee(urn, usr, val);
     }
     function cage() override public auth {
         require(live == 1, "SynthetixJoin/not-live");

--- a/src/test/CropJoin-unit.t.sol
+++ b/src/test/CropJoin-unit.t.sol
@@ -109,8 +109,8 @@ contract Usr {
     function reap() public {
         adapter.join(address(this), address(this), 0);
     }
-    function flee(address urn, address usr) public {
-        adapter.flee(urn, usr);
+    function flee(address urn, address usr, uint256 val) public {
+        adapter.flee(urn, usr, val);
     }
     function tack(address src, address dst, uint256 wad) public {
         adapter.tack(src, dst, wad);
@@ -327,7 +327,7 @@ contract CropUnitTest is TestBase {
         assertEq(gem.balanceOf(address(b)), 200e6,  "b balance before exit");
         assertEq(join.stake(address(b)),       0e18, "b join balance before");
         join.tack(address(a), address(b),     50e18);
-        b.flee(address(b), address(b));
+        b.flee(address(b), address(b), 50e6);
         assertEq(gem.balanceOf(address(b)), 250e6,  "b balance after exit");
         assertEq(join.stake(address(b)),       0e18, "b join balance after");
     }
@@ -390,7 +390,7 @@ contract CropUnitTest is TestBase {
 
         reward(address(join), 10 * 1e18);
         assertEq(gem.balanceOf(self),  950e6, "balance before flee");
-        join.flee(address(this), address(this));
+        join.flee(address(this), address(this), 50 * 1e6);
         assertEq(bonus.balanceOf(self), 20 * 1e18, "rewards invariant over flee");
         assertEq(gem.balanceOf(self), 1000e6, "balance after flee");
     }
@@ -585,7 +585,7 @@ contract CropUnitTest is TestBase {
         // Can still exit and flee
         a.exit(address(a), address(a), 50e6);
         assertEq(gem.balanceOf(address(a)), 150e6);
-        a.flee(address(a), address(a));
+        a.flee(address(a), address(a), 50e6);
         assertEq(gem.balanceOf(address(a)), 200e6);
     }
 

--- a/src/test/Cropper-unit.t.sol
+++ b/src/test/Cropper-unit.t.sol
@@ -76,8 +76,8 @@ contract Usr {
     function reap() public {
         cropper.join(address(adapter), address(this), 0);
     }
-    function flee(address usr) public {
-        cropper.flee(address(adapter), usr);
+    function flee(address usr, uint256 amt) public {
+        cropper.flee(address(adapter), usr, amt);
     }
     function frob(int256 dink, int256 dart) public {
         cropper.frob(adapter.ilk(), address(this), address(this), address(this), dink, dart);
@@ -268,7 +268,7 @@ contract CropperTest is TestBase {
         assertEq(a.gems(), 10 * 1e18);
         assertEq(a.stake(), 10 * 1e18);
         reward(address(join), 50 * 1e18);
-        a.flee(address(a));
+        a.flee(address(a), 10 * 1e6);
         assertEq(gem.balanceOf(address(a)), 200 * 1e6);
         assertEq(gem.balanceOf(address(join)), 0);
         assertEq(bonus.balanceOf(address(a)), 0);   // No rewards with flee
@@ -287,7 +287,7 @@ contract CropperTest is TestBase {
         assertEq(a.gems(), 10 * 1e18);
         assertEq(a.stake(), 10 * 1e18);
         reward(address(join), 50 * 1e18);
-        a.flee(address(b));
+        a.flee(address(b), 10 * 1e6);
         assertEq(gem.balanceOf(address(a)), 190 * 1e6);
         assertEq(gem.balanceOf(address(b)), 210 * 1e6);
         assertEq(gem.balanceOf(address(join)), 0);
@@ -751,6 +751,6 @@ contract CropperTest is TestBase {
         join.exit(address(this), address(this), 0);
     }
     function testFail_crop_flee() public {
-        join.flee(address(this), address(this));
+        join.flee(address(this), address(this), 0);
     }
 }

--- a/src/test/DssProxyActionsCropper.t.sol
+++ b/src/test/DssProxyActionsCropper.t.sol
@@ -85,11 +85,11 @@ contract ProxyCalls {
         proxy.execute(dssProxyActions, msg.data);
     }
 
-    function fleeETH(address, uint256) public {
+    function fleeETH(address, uint256, uint256) public {
         proxy.execute(dssProxyActions, msg.data);
     }
 
-    function fleeGem(address, uint256) public {
+    function fleeGem(address, uint256, uint256) public {
         proxy.execute(dssProxyActions, msg.data);
     }
 
@@ -631,7 +631,7 @@ contract DssProxyActionsTest is DssDeployTestBase, ProxyCalls {
 
         reward(address(ethManagedJoin), 100 * 10 ** 12);
         uint256 prevBalance = address(this).balance;
-        this.fleeETH(address(ethManagedJoin), cdp);
+        this.fleeETH(address(ethManagedJoin), cdp, 1 ether);
         assertEq(vat.gem("ETH", address(this)), 0);
         assertEq(vat.gem("ETH", charterProxy), 0);
         assertEq(address(this).balance, prevBalance + 1 ether);
@@ -649,7 +649,7 @@ contract DssProxyActionsTest is DssDeployTestBase, ProxyCalls {
 
         reward(address(wbtcJoin), 100 * 10 ** 12);
         uint256 prevBalance = wbtc.balanceOf(address(this));
-        this.fleeGem(address(wbtcJoin), cdp);
+        this.fleeGem(address(wbtcJoin), cdp, 2 * 10 ** 8);
         assertEq(vat.gem("WBTC", address(this)), 0);
         assertEq(vat.gem("WBTC", charterProxy), 0);
         assertEq(wbtc.balanceOf(address(this)), prevBalance + 2 * 10 ** 8);

--- a/src/test/LidoJoin-integration.t.sol
+++ b/src/test/LidoJoin-integration.t.sol
@@ -94,8 +94,8 @@ contract Usr {
     function reap() public {
         cropper.join(address(adapter), address(this), 0);
     }
-    function flee() public {
-        cropper.flee(address(adapter), address(this));
+    function flee(uint256 amt) public {
+        cropper.flee(address(adapter), address(this), amt);
     }
     function giveTokens(ERC20 token, uint256 amount) external {
         // Edge case - balance is already set for some reason
@@ -291,7 +291,7 @@ contract LidoIntegrationTest is TestBase {
         assertEq(pool.balanceOf(address(join)), 10 ether);
         assertEq(user1.tokens(), origBal - 10 ether);
 
-        user1.flee();   // Should exit without rewards
+        user1.flee(10 ether);   // Should exit without rewards
 
         assertEq(pool.balanceOf(address(join)), 0 ether);
         assertEq(user1.tokens(), origBal);

--- a/src/test/SushiJoinV1-integration.t.sol
+++ b/src/test/SushiJoinV1-integration.t.sol
@@ -100,8 +100,8 @@ contract Usr {
     function reap() public {
         cropper.join(address(adapter), address(this), 0);
     }
-    function flee() public {
-        cropper.flee(address(adapter), address(this));
+    function flee(uint256 amt) public {
+        cropper.flee(address(adapter), address(this), amt);
     }
     function flux(address src, address dst, uint256 wad) public {
         cropper.flux(address(adapter), src, dst, wad);
@@ -371,7 +371,7 @@ contract SushiV1IntegrationTest is TestBase {
             assertEq(pair.balanceOf(address(join)), join.total());
         }
 
-        usr.flee();
+        usr.flee(amount);
 
         assertEq(join.total(), ptotal - amount);
         assertEq(usr.stake(), 0);

--- a/src/test/SushiJoinV2-integration.t.sol
+++ b/src/test/SushiJoinV2-integration.t.sol
@@ -100,8 +100,8 @@ contract Usr {
     function reap() public {
         cropper.join(address(adapter), address(this), 0);
     }
-    function flee() public {
-        cropper.flee(address(adapter), address(this));
+    function flee(uint256 amt) public {
+        cropper.flee(address(adapter), address(this), amt);
     }
     function flux(address src, address dst, uint256 wad) public {
         cropper.flux(address(adapter), src, dst, wad);
@@ -391,7 +391,7 @@ contract SushiIntegrationTest is TestBase {
             assertEq(pair.balanceOf(address(join)), join.total());
         }
 
-        usr.flee();
+        usr.flee(amount);
 
         assertEq(join.total(), ptotal - amount);
         assertEq(usr.stake(), 0);


### PR DESCRIPTION
The change here is motivated by the fact the when vaults are skimmed, there is no guarantee (and no incentive as well) for them to be tacked as well.
If not all vaults are tacked after skim then End will not have enough stake, so even if users that call cash() tack from End to their address, there will not be enough stakes for all of them to exit throuh cropper.

Therefore it is simpler to just flee the gems at cash stage, even if it means giving up on some rewards.
Note that vaults can be harvested right before the skim call anyway by their original user (and they are actually harvested in End's freeETH/freeGem proxy actions in between), so there will not be much reward for dai holders anyway.

The above required to change CropJoin's flee() functionality and interface to get a `val` parameter instead of fleeing all ink.
This is actually better in my opinion as now it is pairwised with exit() in functionality and interface.
